### PR TITLE
feat: add intake wizard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,21 +1,21 @@
 # app/main.py
 from pathlib import Path  # ✅ add this
+
 from fastapi import FastAPI, Request
-from .routers import health as health_router
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from .config import FRONTEND_ORIGINS
-from .db import users_col
+from .db import intake_col, users_col
 from .deps import get_user_by_id
-from .security import parse_session_cookie
-
-from .routers.pages import router as pages_router
-from .routers.auth_routes import router as auth_router
-from .routers.rewards import router as rewards_router
+from .routers import health as health_router
 from .routers.admin_intake import router as admin_router
+from .routers.auth_routes import router as auth_router
 from .routers.deva import router as deva_router
-# from datetime import datetime  # ❌ remove (unused)
+from .routers.intake import router as intake_router
+from .routers.pages import router as pages_router
+from .routers.rewards import router as rewards_router
+from .security import parse_session_cookie
 
 BASE_DIR = Path(__file__).resolve().parent
 STATIC_DIR = BASE_DIR / "static"
@@ -34,10 +34,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 # Health
 @app.get("/healthz")
 async def healthz():
     return {"ok": True}
+
 
 # Attach user to request.state on every request
 @app.middleware("http")
@@ -52,15 +54,17 @@ async def inject_user(request: Request, call_next):
     request.state.user = await get_user_by_id(uid) if uid else None
     return await call_next(request)
 
+
 # Startup tasks
 @app.on_event("startup")
 async def _ensure_user_index():
     await users_col.create_index("email", unique=True)
 
-from .db import intake_col
+
 @app.on_event("startup")
 async def _ensure_intake_index():
     await intake_col.create_index("id", unique=True)
+
 
 # Routers
 app.include_router(pages_router)
@@ -68,3 +72,4 @@ app.include_router(auth_router)
 app.include_router(rewards_router)
 app.include_router(admin_router)
 app.include_router(deva_router)
+app.include_router(intake_router)

--- a/app/routers/intake.py
+++ b/app/routers/intake.py
@@ -1,0 +1,48 @@
+# app/routers/intake.py
+"""Endpoints for the intake wizard used to create a new plan."""
+from typing import Any, Dict
+
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from ..db import intake_col, users_col
+from ..deps import require_uid_cookie
+
+router = APIRouter()
+
+
+@router.get("/api/intake/questions")
+async def get_intake_questions(
+    _uid: str = Depends(require_uid_cookie),
+) -> Dict[str, Any]:
+    """Return all intake questions ordered by their id.
+
+    The client side wizard uses these questions to render the interview.
+    """
+    cur = intake_col.find({}, {"_id": 0}).sort("id", 1)
+    questions = [q async for q in cur]
+    return {"questions": questions}
+
+
+class IntakeAnswers(BaseModel):
+    """Payload for saving intake answers."""
+
+    answers: Dict[str, Any]
+
+
+@router.post("/api/intake/answers")
+async def save_intake_answers(
+    payload: IntakeAnswers, uid: str = Depends(require_uid_cookie)
+) -> Dict[str, Any]:
+    """Store the provided answers on the user document.
+
+    If the user document does not yet exist, raise an error.
+    """
+    oid = ObjectId(uid)
+    res = await users_col.update_one(
+        {"_id": oid}, {"$set": {"intake_answers": payload.answers}}, upsert=False
+    )
+    if res.matched_count == 0:
+        raise HTTPException(status_code=404, detail="user not found")
+    return {"ok": True}

--- a/app/static/js/intake.js
+++ b/app/static/js/intake.js
@@ -1,0 +1,81 @@
+// app/static/js/intake.js
+// Simple client-side wizard for answering intake questions sequentially.
+let questions = [];
+let index = 0;
+const answers = {};
+
+async function loadQuestions() {
+  try {
+    const res = await fetch('/api/intake/questions');
+    if (!res.ok) throw new Error('Failed to load');
+    const data = await res.json();
+    questions = data.questions || [];
+    if (questions.length === 0) {
+      document.getElementById('question').textContent = 'No questions available.';
+    } else {
+      renderQuestion();
+    }
+  } catch (err) {
+    document.getElementById('question').textContent = 'Error loading questions.';
+  }
+}
+
+function renderQuestion() {
+  const q = questions[index];
+  const container = document.getElementById('question');
+  container.innerHTML = '';
+  const label = document.createElement('p');
+  label.textContent = q.text;
+  container.appendChild(label);
+  if ((q.type === 'single-select' || q.type === 'multi-select') && q.options) {
+    const list = document.createElement('div');
+    q.options.forEach((o, i) => {
+      const wrap = document.createElement('label');
+      const input = document.createElement('input');
+      input.type = q.type === 'multi-select' ? 'checkbox' : 'radio';
+      input.name = 'answer';
+      input.value = o.value || o.text;
+      wrap.appendChild(input);
+      wrap.appendChild(document.createTextNode(o.text));
+      list.appendChild(wrap);
+    });
+    container.appendChild(list);
+  } else {
+    const input = document.createElement('input');
+    input.type = q.type === 'number' ? 'number' : 'text';
+    input.id = 'answer';
+    container.appendChild(input);
+  }
+}
+
+async function next() {
+  const q = questions[index];
+  let val;
+  if (q.type === 'multi-select') {
+    val = Array.from(
+      document.querySelectorAll('input[name="answer"]:checked')
+    ).map((el) => el.value);
+  } else if (q.type === 'single-select') {
+    const selected = document.querySelector('input[name="answer"]:checked');
+    val = selected ? selected.value : null;
+  } else {
+    val = document.getElementById('answer').value;
+  }
+  answers[q.variable_name] = val;
+  index += 1;
+  if (index < questions.length) {
+    renderQuestion();
+  } else {
+    await fetch('/api/intake/answers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ answers }),
+    });
+    window.location.href = '/dashboard';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('nextBtn').addEventListener('click', next);
+  loadQuestions();
+});

--- a/app/templates/intake.html
+++ b/app/templates/intake.html
@@ -1,23 +1,18 @@
-<!doctype html>
-<html lang="en">
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>Intake · Fitn</title>
-<style>
-  :root { --bg:#fafafa; --card:#fff; --text:#111; --muted:#666; --line:#eee; --accent:#111; }
-  *{ box-sizing:border-box; }
-  body{ margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial; background:var(--bg); color:var(--text); }
-  .wrap{ max-width:800px; margin:0 auto; padding:16px; }
-  .card{ background:var(--card); border:1px solid var(--line); border-radius:12px; padding:16px; }
-  .btn{ display:inline-block; padding:10px 12px; border:none; border-radius:10px; background:#111; color:#fff; font-weight:700; text-decoration:none; }
-</style>
-<body>
-  <div class="wrap">
-    <div class="card">
-      <h1 style="margin:0 0 8px;">Planner Intake</h1>
-      <p style="color:#666">This is a placeholder. The interview wizard will live here (Identity, Daily Rhythm, Diet, Sleep, Fitness, Rewards…).</p>
-      <p><a class="btn" href="/dashboard">Back to Dashboard</a></p>
+{% extends "base.html" %}
+{% block title %}Intake · Fitn{% endblock %}
+
+{% block content %}
+<div class="wrap">
+  <div class="card" id="wizard">
+    <h1>Planner Intake</h1>
+    <div id="question"></div>
+    <div class="controls">
+      <button id="nextBtn" class="btn">Next</button>
     </div>
   </div>
-</body>
-</html>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script defer src="{{ url_for('static', path='js/intake.js') }}"></script>
+{% endblock %}

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_intake_requires_authentication():
+    client = TestClient(app)
+    res = client.get("/api/intake/questions")
+    assert res.status_code == 403


### PR DESCRIPTION
## Summary
- add API endpoints and frontend wizard for intake questions
- wire intake router into app
- test intake route auth requirement
- render single- and multi-select questions with radio buttons or checkboxes instead of dropdowns

## Testing
- `pre-commit run --files app/static/js/intake.js`
- `OPENAI_API_KEY=dummy PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c047ef38d0832fafdeff7320ae8d1a