### PR TITLE
Enhance intake wizard with progress and autosave

### DIFF
--- a/app/static/css/intake.css
+++ b/app/static/css/intake.css
@@ -1,0 +1,41 @@
+#progress {
+  height: 8px;
+  background: var(--line);
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 10px 0 20px;
+}
+#progressBar {
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  transition: width 0.2s ease;
+}
+.question {
+  margin-bottom: 20px;
+}
+.option {
+  display: block;
+  margin-bottom: 8px;
+}
+.option input {
+  transform: scale(1.4);
+  margin-right: 8px;
+}
+.controls {
+  margin-top: 20px;
+}
+.btn.disabled {
+  opacity: 0.5;
+}
+#toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 4px;
+  display: none;
+}

--- a/app/templates/intake.html
+++ b/app/templates/intake.html
@@ -1,14 +1,18 @@
 {% extends "base.html" %} {% block title %}Intake · Fitn{% endblock %} {% block
-content %}
+styles %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/intake.css') }}" />
+{% endblock %} {% block content %}
 <div class="wrap">
   <div class="card" id="wizard">
     <h1>Planner Intake</h1>
+    <div id="progress"><div id="progressBar"></div></div>
     <div id="question"></div>
     <div class="controls">
-      <button id="nextBtn" class="btn" disabled>Next</button>
+      <button id="nextBtn" class="btn disabled">Next</button>
     </div>
   </div>
 </div>
+<div id="toast" class="toast"></div>
 {% endblock %} {% block scripts %}
 <script defer src="{{ url_for('static', path='js/intake.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow editing question IDs and improved natural ordering in admin intake
- add progress bar, autosave with resume prompt, and validation toast to intake wizard
- style intake wizard for better mobile usability

## Testing
- `pre-commit run --files app/static/js/admin_intake.js app/routers/admin_intake.py app/routers/intake.py app/templates/intake.html app/static/js/intake.js app/static/css/intake.css`
- `OPENAI_API_KEY=dummy PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1884c2484832faab507b2190c9b28